### PR TITLE
chore: upload-pages-artifact 버전 변경

### DIFF
--- a/.github/workflows/deploy-gatsby-site-to-pages.yml
+++ b/.github/workflows/deploy-gatsby-site-to-pages.yml
@@ -76,7 +76,7 @@ jobs:
           yarn build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
v1 -> v3

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/