### PR TITLE
fix: deploy-pages 버전 변경

### DIFF
--- a/.github/workflows/deploy-gatsby-site-to-pages.yml
+++ b/.github/workflows/deploy-gatsby-site-to-pages.yml
@@ -89,4 +89,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
v2 -> v4

Error: Error: No uploaded artifact was found! Please check if there are any errors at build step, or uploaded artifact name is correct.
    at getSignedArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/api-client.js:94:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/deployment.js:68:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v2/src/index.js:30:1)
Error: Error: No uploaded artifact was found! Please check if there are any errors at build step, or uploaded artifact name is correct.